### PR TITLE
Removing the master and slave language

### DIFF
--- a/server/server/server.py
+++ b/server/server/server.py
@@ -326,7 +326,7 @@ class IRCSide(threading.Thread):
 
     def start_pull_thread(self):
         """
-        Starts the slave thread for pulling/inserting/changing new client IO from the database.
+        Starts the subordinate thread for pulling/inserting/changing new client IO from the database.
         """
         threading.Thread(target=self._pull_thread).start()
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.